### PR TITLE
add CI to ensure license header present as appropriate

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,86 @@
+# Copyright The Conforma Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: License Header Check
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  license-check:
+    runs-on: ubuntu-latest
+    name: Check License Headers
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.24.4'
+        
+    - name: Check License Headers
+      run: |
+        echo "🔍 Checking license headers..."
+        go run -modfile tools/go.mod github.com/google/addlicense -check -ignore '.github/ISSUE_TEMPLATE/**' -ignore '.github/PULL_REQUEST_TEMPLATE/**' -ignore '.github/dependabot.yml' -ignore 'vendor/**' -ignore 'node_modules/**' -ignore '*.md' -ignore '*.json' -ignore 'go.mod' -ignore 'go.sum' -ignore 'LICENSE' -ignore 'ko.yaml' -ignore '.ko.yaml' -ignore '.golangci.yml' -c 'The Conforma Contributors' -s -y 2025 .
+          
+    - name: Show license header format on failure
+      if: failure()
+      run: |
+        echo "💥 Some files are missing license headers!"
+        echo ""
+        echo "📋 Expected license header format:"
+        echo ""
+        echo "For Go files (.go):"
+        echo "// Copyright The Conforma Contributors"
+        echo "//"
+        echo "// Licensed under the Apache License, Version 2.0 (the \"License\");"
+        echo "// you may not use this file except in compliance with the License."
+        echo "// You may obtain a copy of the License at"
+        echo "//"
+        echo "//      http://www.apache.org/licenses/LICENSE-2.0"
+        echo "//"
+        echo "// Unless required by applicable law or agreed to in writing, software"
+        echo "// distributed under the License is distributed on an \"AS IS\" BASIS,"
+        echo "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied."
+        echo "// See the License for the specific language governing permissions and"
+        echo "// limitations under the License."
+        echo "//"
+        echo "// SPDX-License-Identifier: Apache-2.0"
+        echo ""
+        echo "For YAML/Shell files (.yaml, .yml, .sh, Makefile):"
+        echo "# Copyright The Conforma Contributors"
+        echo "#"
+        echo "# Licensed under the Apache License, Version 2.0 (the \"License\");"
+        echo "# you may not use this file except in compliance with the License."
+        echo "# You may obtain a copy of the License at"
+        echo "#"
+        echo "#      http://www.apache.org/licenses/LICENSE-2.0"
+        echo "#"
+        echo "# Unless required by applicable law or agreed to in writing, software"
+        echo "# distributed under the License is distributed on an \"AS IS\" BASIS,"
+        echo "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied."
+        echo "# See the License for the specific language governing permissions and"
+        echo "# limitations under the License."
+        echo "#"
+        echo "# SPDX-License-Identifier: Apache-2.0"
+        echo ""
+        echo "To fix missing headers, you can run:"
+        echo "make license-add"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,3 +1,19 @@
+# Copyright The Conforma Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: CI/CD Pipeline
 
 on:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,34 @@
+# Copyright The Conforma Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Configuration for addlicense tool
+ignore:
+  - '.github/**'
+  - 'vendor/**'
+  - 'node_modules/**'
+  - '*.md'
+  - '*.json'
+  - 'go.mod'
+  - 'go.sum'
+  - 'LICENSE'
+  - 'ko.yaml'
+  - '.ko.yaml'
+  - '.golangci.yml'
+  - '.licenserc.yaml'
+
+copyright: 'The Conforma Contributors'
+style: 'only'
+year: 2025

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.25.1
+golang 1.24.4

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,15 @@ EVENT_SOURCE_SELECTOR := eventing.knative.dev/sourceName=snapshot-events
 CLUSTER_NAME = $(shell kubectl config current-context | sed 's/kind-//')
 IS_KIND_CLUSTER = $(shell kubectl config current-context | grep -q "kind" && echo "true" || echo "false")
 
+# === LICENSE CHECKING ===
+.PHONY: license-check
+license-check: ## Check license headers in source files
+	@go run -modfile tools/go.mod github.com/google/addlicense -check -ignore '.github/ISSUE_TEMPLATE/**' -ignore '.github/PULL_REQUEST_TEMPLATE/**' -ignore '.github/dependabot.yml' -ignore 'vendor/**' -ignore 'node_modules/**' -ignore '*.md' -ignore '*.json' -ignore 'go.mod' -ignore 'go.sum' -ignore 'LICENSE' -ignore 'ko.yaml' -ignore '.ko.yaml' -ignore '.golangci.yml' -c 'The Conforma Contributors' -s -y 2025 .
+
+.PHONY: license-add
+license-add: ## Add license headers to source files that are missing them
+	@go run -modfile tools/go.mod github.com/google/addlicense -ignore '.github/ISSUE_TEMPLATE/**' -ignore '.github/PULL_REQUEST_TEMPLATE/**' -ignore '.github/dependabot.yml' -ignore 'vendor/**' -ignore 'node_modules/**' -ignore '*.md' -ignore '*.json' -ignore 'go.mod' -ignore 'go.sum' -ignore 'LICENSE' -ignore 'ko.yaml' -ignore '.ko.yaml' -ignore '.golangci.yml' -c 'The Conforma Contributors' -s -y 2025 .
+
 # === SHELL FUNCTIONS ===
 SHELL_FUNCTIONS = resolve_registry_image() { if [[ "$(KO_DOCKER_REPO)" == *":"* ]]; then echo "$(KO_DOCKER_REPO)"; else echo "$(KO_DOCKER_REPO):latest"; fi; }; \
 build_local_image() { echo "🔨 Building image locally with ko..." >&2; KO_DOCKER_REPO=ko.local ko build --local ./cmd/launch-taskrun 2>/dev/null | tail -1; }; \

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+# Copyright 2025 The Conforma Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 echo "* Deleting old snapshot..."

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,0 +1,26 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+module tools
+
+go 1.24.4
+
+require github.com/google/addlicense v1.1.1
+
+require (
+	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+)

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,0 +1,6 @@
+github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/google/addlicense v1.1.1 h1:jpVf9qPbU8rz5MxKo7d+RMcNHkqxi4YJi/laauX4aAE=
+github.com/google/addlicense v1.1.1/go.mod h1:Sm/DHu7Jk+T5miFHHehdIjbi4M5+dJDRS3Cq0rncIxA=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,0 +1,23 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build tools
+
+package tools
+
+import (
+	_ "github.com/google/addlicense"
+)


### PR DESCRIPTION
This commit implements `Makefile` targets as well as Git Hub workflows that detect and correct missing license headers in appropriate files.

Ref: EC-1498