### PR TITLE
only run `license-check` workflow on PRs, not merge

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -17,10 +17,8 @@
 name: License Header Check
 
 on:
-  push:
-    branches: [ main, master ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
 
 jobs:
   license-check:


### PR DESCRIPTION
This commit updates the `github/workflows/license-check.yml` workflow to only execute on PRs to the `main` branch, not when actually merging, as that would be redundant.