### PR TITLE
Scope RBAC permissions to least-privilege namespace grants

### DIFF
--- a/config/base/rbac.yaml
+++ b/config/base/rbac.yaml
@@ -20,6 +20,7 @@ metadata:
   name: conforma-knative-service
   namespace: conforma
 ---
+# Controller namespace Role: ConfigMap reads and Job management in conforma ns
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -46,7 +47,7 @@ roleRef:
   name: conforma-knative-service
   apiGroup: rbac.authorization.k8s.io
 ---
-# ClusterRole for cross-namespace access to resources
+# ClusterRole: cross-namespace access to Konflux CRDs only
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -55,18 +56,6 @@ rules:
   - apiGroups: ["appstudio.redhat.com"]
     resources: ["snapshots", "releaseplans", "releaseplanadmissions", "enterprisecontractpolicies"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["secrets", "configmaps"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["pods/log"]
-    verbs: ["get", "list"]
-  - apiGroups: ["batch"]
-    resources: ["jobs"]
-    verbs: ["create", "get", "list", "watch", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -88,18 +77,58 @@ metadata:
   name: conforma-vsa-generator
   namespace: conforma
 ---
-# ClusterRoleBinding to give job pods the same permissions as the controller
-# Jobs now run in conforma namespace and need cluster-wide access to read
-# snapshots, policies, and secrets from any namespace
+# Job SA: get the VSA signing key in conforma namespace.
+# If VSA_SIGNING_KEY_SECRET_NAME is changed in the ConfigMap,
+# update resourceNames here to match.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: Role
 metadata:
-  name: conforma-vsa-generator-cluster
+  name: conforma-vsa-generator
+  namespace: conforma
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+    resourceNames: ["vsa-signing-key"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conforma-vsa-generator
+  namespace: conforma
 subjects:
   - kind: ServiceAccount
     name: conforma-vsa-generator
     namespace: conforma
 roleRef:
-  kind: ClusterRole
-  name: conforma-knative-service-cluster
+  kind: Role
+  name: conforma-vsa-generator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Job SA: get the public verification key in openshift-pipelines namespace.
+# If PUBLIC_KEY is changed in the ConfigMap to reference a different
+# secret name or namespace, update this Role/RoleBinding to match.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: conforma-vsa-generator
+  namespace: openshift-pipelines
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+    resourceNames: ["public-key"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conforma-vsa-generator
+  namespace: openshift-pipelines
+subjects:
+  - kind: ServiceAccount
+    name: conforma-vsa-generator
+    namespace: conforma
+roleRef:
+  kind: Role
+  name: conforma-vsa-generator
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary

- **Stripped ClusterRole to CRDs only** — removed cluster-wide `get/list/watch` on secrets/configmaps, `create/update/patch` on pods/jobs, and `get/list` on pods/log. The ClusterRole now only grants access to Konflux CRDs (Snapshots, ReleasePlans, ReleasePlanAdmissions, EnterpriseContractPolicies) which genuinely need cross-namespace access.

- **Removed Job SA ClusterRoleBinding** — the `conforma-vsa-generator` SA no longer inherits the CRD ClusterRole. Job pods don't need CRD access — snapshot spec and policy config are passed as CLI arguments.

- **Added namespace-scoped Roles for secret access** — the Job SA now gets `get` (no `list/watch`) on specific named secrets only:
  - `vsa-signing-key` in `conforma` namespace
  - `public-key` in `openshift-pipelines` namespace
  - Both use `resourceNames` restrictions so no other secrets are accessible

- **Dropped pod write verbs entirely** — `create/update/patch` on pods was never needed; the Kubernetes Job controller manages pod lifecycle.

### Before vs After

| Permission | Before | After |
|-----------|--------|-------|
| Secrets | `get/list/watch` on ALL secrets cluster-wide | `get` only, 2 named secrets in 2 namespaces |
| Pods | `get/list/watch/create/update/patch` cluster-wide | Removed entirely |
| Pods/log | `get/list` cluster-wide | Removed entirely |
| Jobs | `create/get/list/watch/update/patch` cluster-wide | `create/get/list/watch` in conforma ns only (existing Role) |
| ConfigMaps | `get/list/watch` cluster-wide | `get/list` in conforma ns only (existing Role) |
| CRDs | cluster-wide | cluster-wide (unchanged, controller needs this) |

### Notes

- Secret names are configurable via ConfigMap (`VSA_SIGNING_KEY_SECRET_NAME`, `PUBLIC_KEY`). If changed, the corresponding `resourceNames` in the Roles must be updated. This is documented in comments.
- Verified that the CLI uses `Secrets().Get()` (not `List`) for `k8s://` URI resolution, so `get` with `resourceNames` is sufficient.

## Test plan

- [x] `kubectl kustomize config/base/` renders valid manifests
- [ ] Deploy to a test cluster and verify VSA generation succeeds with scoped permissions

Resolves: EC-2046

🤖 Generated with [Claude Code](https://claude.com/claude-code)